### PR TITLE
Removed unused member variable MH from Renormalization class

### DIFF
--- a/src/include/SingletEWPT/renormalization.h
+++ b/src/include/SingletEWPT/renormalization.h
@@ -58,7 +58,7 @@ private:
     const double Mt = ExperimentalInput::Mt;
     const double MW = ExperimentalInput::MW;
     const double MZ = ExperimentalInput::MZ;
-    const double MH = ExperimentalInput::MW;
+    
     // Alias for g3sq, SU(3) coupling
     const double gs2 = ExperimentalInput::gs2;
     // SU(3) coupling


### PR DESCRIPTION
Constant Renormalization::MH was incorrectly set to W-mass instead of H-mass. Fortunately the variable was never used for anything so no damage caused