### PR TITLE
- Removed use of FetchContent with Boost libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,30 @@
 
 Program that does stuff
 
-# Dependencies
+## Dependencies
 
 - dlib C++ library
-- Boost odeint
+- Boost
 
-# Installation
+## Installation
+
+### Installing dependencies
+
+You will need to manually install the Boost C++ libraries.
+Linux:
+```
+sudo apt-get install libboost-all-dev
+```
+
+MacOS:
+```
+brew install boost
+```
+
+For dlib, you can either manually install the libraries from http://dlib.net, or let CMake automatically fetch it for you in the next step.
+
+
+### Building the program
 
 ```
 mkdir build
@@ -17,9 +35,7 @@ make
 make install	
 ```
 
-The 
-
-# Debugging
+## Debugging
 
 To build debug version and unit tests use the ```-DCMAKE_BUILD_TYPE=Debug``` flag when calling cmake, ie:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,51 +10,40 @@ set(COMMON_SOURCES betafunct.cpp dimred.cpp PassarinoVeltman.cpp renormalization
 add_library(${MAIN_LIB} STATIC ${COMMON_SOURCES})
 
 
+## ------ Find/fetch external packages
+message(STATUS "Loading external libraries")
+
 include(FetchContent)
+Set(FETCHCONTENT_QUIET FALSE) ## Show what the fetching is doing
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
 
-# Attempt to locate third-party packages
+# Boost: FetchContent apparently does not work well with Boost
+
 find_package(Boost REQUIRED)
-find_package(dlib REQUIRED)
 
-if(NOT Boost_FOUND)
+# dlib: Fetch if not found on the system
+find_package(dlib QUIET)
 
-	message(STATUS "Could not find Boost libraries. Attempting to fetch...")
-	Set(FETCHCONTENT_QUIET FALSE) ## Long process so we want to see what it's doing
-	
-	set(BOOST_ENABLE_CMAKE ON)
-	FetchContent_Declare(
-	  Boost
-	  GIT_REPOSITORY https://github.com/boostorg/boost.git
-	  GIT_TAG boost-1.82.0
-	  GIT_PROGRESS TRUE
-	)
-	FetchContent_MakeAvailable(Boost)
-
-endif()
-
-
-if(NOT dlib_FOUND)
-
-	message(STATUS "Could not find dlib libraries. Attempting to fetch...")
-	Set(FETCHCONTENT_QUIET FALSE)
+if (NOT dlib_FOUND)
+	message(STATUS "dlib not found, attempting to fetch")
 	FetchContent_Declare(dlib
 		GIT_REPOSITORY https://github.com/davisking/dlib.git
-		GIT_TAG        v19.18
+		GIT_TAG        v19.24.2
 		GIT_PROGRESS TRUE
 	)
 	FetchContent_MakeAvailable(dlib)
-
 endif()
 
+## ------- 
 
 target_include_directories(${MAIN_LIB} PRIVATE 
 	${CMAKE_CURRENT_SOURCE_DIR}/include/SingletEWPT
 	dlib::dlib # dlib_INCLUDE_DIRS is apparently deprecated
-    ${Boost_INCLUDE_DIRS}
+    Boost::boost
 )
 
 ## Public linkage to external libs
-target_link_libraries(${MAIN_LIB} PUBLIC dlib::dlib ${Boost_LIBRARIES})
+target_link_libraries(${MAIN_LIB} PUBLIC dlib::dlib Boost::boost)
 
 ## The 'main' program
 add_executable(${MAIN_EXEC} main.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,20 +1,26 @@
 # Get latest release of Google Test from github 
 include(FetchContent)
+Set(FETCHCONTENT_QUIET FALSE) ## Show what the fetching is doing
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
 
+## Fetch Google Test library
+include(FetchContent)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        main
+  GIT_TAG        v1.13.0
 )
 
-# Set options for fetching Google Test
+# For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-set(gtest_disable_pthreads ON CACHE BOOL "" FORCE)
 
-
-## Fetch Google Test library
-message(STATUS "Fetching Google Test...")
-FetchContent_MakeAvailable(googletest)
+#FetchContent_MakeAvailable(googletest)
+## This should be equivalent to FetchContent_MakeAvailable, except that we exclude gtest from install
+FetchContent_GetProperties(googletest)
+if(NOT googletest_POPULATED)
+  FetchContent_Populate(googletest)
+  add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()
 
 
 set(TEST_EXEC ${MAIN_EXEC}_Tests)


### PR DESCRIPTION
- Just using find_package now for Boost

- googletest is now excluded from 'make install'. No more permission denied errors when installing without sudo.